### PR TITLE
Add pagination to products list page

### DIFF
--- a/src/pages/products/index.astro
+++ b/src/pages/products/index.astro
@@ -1,6 +1,15 @@
 ---
+export const prerender = false;
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { db, Product, Review, avg } from 'astro:db';
+import { db, Product, Review, avg, count } from 'astro:db';
+
+const PAGE_SIZE = 9;
+const page = Math.max(1, Number(Astro.url.searchParams.get('page')) || 1);
+
+const [{ total }] = await db.select({ total: count() }).from(Product);
+const totalPages = Math.ceil(total / PAGE_SIZE);
+const currentPage = Math.min(page, totalPages);
+const offset = (currentPage - 1) * PAGE_SIZE;
 
 const products = await db
   .select({
@@ -10,7 +19,9 @@ const products = await db
     roast: Product.roast,
   })
   .from(Product)
-  .orderBy(Product.name);
+  .orderBy(Product.name)
+  .limit(PAGE_SIZE)
+  .offset(offset);
 
 const avgRatings = await db
   .select({
@@ -46,4 +57,27 @@ const productsWithRatings = products.map(p => ({
       </article>
     ))}
   </div>
+  {totalPages > 1 && (
+    <nav class="pagination" aria-label="Products pagination">
+      {currentPage > 1 ? (
+        <a href={`/products?page=${currentPage - 1}`} class="pagination-btn">&larr; Previous</a>
+      ) : (
+        <span class="pagination-btn disabled">&larr; Previous</span>
+      )}
+      <div class="pagination-pages">
+        {Array.from({ length: totalPages }, (_, i) => i + 1).map(p => (
+          p === currentPage ? (
+            <span class="pagination-num active">{p}</span>
+          ) : (
+            <a href={`/products?page=${p}`} class="pagination-num">{p}</a>
+          )
+        ))}
+      </div>
+      {currentPage < totalPages ? (
+        <a href={`/products?page=${currentPage + 1}`} class="pagination-btn">Next &rarr;</a>
+      ) : (
+        <span class="pagination-btn disabled">Next &rarr;</span>
+      )}
+    </nav>
+  )}
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,7 +30,9 @@ body { font-family: system-ui, -apple-system, sans-serif; background: #faf8f5; c
 .blog-post a { color: #8b4513; }
 
 /* Products grid */
-.product-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 2rem; }
+.product-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 2rem; }
+@media (max-width: 900px) { .product-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 560px) { .product-grid { grid-template-columns: 1fr; } }
 .product-card { background: #fff; border: 1px solid #e0d6c8; border-radius: 8px; padding: 1.5rem; position: relative; text-decoration: none; color: inherit; }
 .product-card h2 { color: #2c1810; }
 .product-card .price { font-size: 1.5rem; font-weight: bold; color: #2c1810; }
@@ -48,6 +50,16 @@ body { font-family: system-ui, -apple-system, sans-serif; background: #faf8f5; c
 .filter-control a, .sort-control a { color: #8b4513; text-decoration: none; padding: 0.3rem 0.7rem; border-radius: 4px; border: 1px solid transparent; }
 .filter-control a.active, .sort-control a.active { background: #2c1810; color: #f5f0e8; }
 .filter-control a:hover:not(.active), .sort-control a:hover:not(.active) { border-color: #e0d6c8; }
+/* Pagination */
+.pagination { display: flex; justify-content: center; align-items: center; gap: 1rem; margin-top: 2.5rem; padding: 1rem 0; }
+.pagination-btn { color: #8b4513; text-decoration: none; padding: 0.5rem 1rem; border: 1px solid #e0d6c8; border-radius: 4px; font-size: 0.95rem; transition: all 0.2s; }
+.pagination-btn:hover { background: #2c1810; color: #f5f0e8; border-color: #2c1810; }
+.pagination-btn.disabled { color: #ccc; border-color: #e0d6c8; pointer-events: none; }
+.pagination-pages { display: flex; gap: 0.35rem; }
+.pagination-num { display: inline-flex; align-items: center; justify-content: center; width: 2.2rem; height: 2.2rem; border-radius: 4px; text-decoration: none; font-size: 0.95rem; color: #8b4513; border: 1px solid #e0d6c8; transition: all 0.2s; }
+.pagination-num:hover { background: #f0ebe4; }
+.pagination-num.active { background: #2c1810; color: #f5f0e8; border-color: #2c1810; font-weight: 600; }
+
 .card-rating { display: flex; align-items: center; gap: 0.4rem; margin: 0.25rem 0 0.5rem; }
 .card-rating .stars { color: #d4a017; font-size: 1.1rem; letter-spacing: 0.05em; }
 .card-rating .rating-value { font-size: 0.85rem; color: #888; }


### PR DESCRIPTION
## Summary

Adds server-side pagination to the products list page, displaying 9 products per page in a 3×3 grid with Previous/Next navigation and numbered page links.

## Background

The products page currently loads all 30 coffees at once, which is overwhelming for users browsing the catalog.

Closes #4

## Changes

- **`src/pages/products/index.astro`** — Added `prerender = false` for SSR, query param-based pagination with `LIMIT`/`OFFSET`, and a pagination nav with Previous/Next buttons and numbered page links.
- **`src/styles/global.css`** — Changed the product grid to `repeat(3, 1fr)` for a consistent 3×3 layout, added responsive breakpoints (2-col ≤900px, 1-col ≤560px), and added pagination component styles.

## Testing

- Build verified with `ASTRO_DATABASE_FILE=fourth-coffee.db npm run build` — succeeds with no errors.
- Products index page is now server-rendered (not prerendered) to support query param pagination.
- With 30 products, produces 4 pages (9 + 9 + 9 + 3).

## Additional Notes

- No breaking changes. The default page (no query param) shows the first 9 products, same as `?page=1`.